### PR TITLE
Geometry API redesign

### DIFF
--- a/megaman/geometry/affinity.py
+++ b/megaman/geometry/affinity.py
@@ -1,4 +1,52 @@
+from __future__ import division ## removes integer division
+import numpy as np
+from scipy import sparse
+from scipy.spatial.distance import pdist
+import subprocess, os, sys, warnings
 
 
 def compute_affinity_matrix(adjacency_matrix, method, **kwargs):
-    pass
+    if kwargs is None:
+        kwargs = {'radius':1./adjacency_matrix.shape[0]}
+    elif 'radius' not in kwargs.keys():
+        kwargs['radius'] = 1./adjacency_matrix.shape[0]
+    return affinity_matrix(adjacency_matrix, **kwargs)
+    
+def symmetrize_sparse(A):
+    """
+    Symmetrizes a sparse matrix in place (coo and csr formats only)
+
+    NOTES:
+    1. if there are values of 0 or 0.0 in the sparse matrix, this operation will DELETE them.
+    """
+    if A.getformat() is not "csr":
+        A = A.tocsr()
+    A = (A + A.transpose(copy = True))/2
+    return A
+
+def affinity_matrix(distances, radius, symmetrize = True):
+    if radius <= 0.:
+        raise ValueError('radius must be >0.')
+    A = distances.copy()
+    if sparse.isspmatrix( A ):
+        A.data = A.data**2
+        A.data = A.data/(-radius**2)
+        np.exp( A.data, A.data )
+        if symmetrize:
+            A = symmetrize_sparse( A )  # converts to CSR; deletes 0's
+        else:
+            pass
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # sparse will complain that this is faster with lil_matrix
+            A.setdiag(1) # the 0 on the diagonal is a true zero
+    else:
+        A **= 2
+        A /= (-radius**2)
+        np.exp(A, A)
+        if symmetrize:
+            A = (A+A.T)/2
+            A = np.asarray( A, order="C" )  # is this necessary??
+        else:
+            pass
+    return A

--- a/megaman/geometry/distance.py
+++ b/megaman/geometry/distance.py
@@ -11,7 +11,8 @@ from .cyflann.index import Index
 
 
 def compute_adjacency_matrix(X, method='auto', **kwargs):
-    pass
+    graph = distance_matrix(X, method = 'auto', **kwargs)
+    return graph
 
 
 def _row_col_from_condensed_index(N,compr_ind):

--- a/megaman/geometry/geometry_new.py
+++ b/megaman/geometry/geometry_new.py
@@ -1,0 +1,243 @@
+"""
+Scalable Manifold learning utilities and algorithms.
+
+Graphs are represented with their weighted adjacency matrices, preferably using
+sparse matrices.
+
+A note on symmetrization and internal sparse representations
+------------------------------------------------------------
+
+For performance, this code uses the FLANN library to compute
+approximate neighborhoods efficiently. This means that (1) the 
+adjacency matrix produced is NOT GUARANTEED to be symmetric and 
+(2) compute_adjacency_matrix returns a sparse matrix called 
+adjacency_matrix. adjacency_matrix has 0.0 on the diagonal, 
+as it should. Implicitly, the missing entries are infinity not 
+0 for this matrix. But (1) and (2) mean that if one tries to 
+symmetrize adjacency_matrix, the scipy.sparse code eliminates 
+the 0.0 entries from adjacency_matrix hence in the affinity
+matrix we explicitly set the diagonal to 1.0 for sparse matrices.
+
+We adopted the following convention:
+   * affinity_matrix will NOT BE GUARANTEED symmetric
+   * affinity_matrix will perform a symmetrization by default
+   * laplacian does NOT perform symmetrization by default, 
+     only if symmetrize=True, and DOES NOT check symmetry
+   * these conventions are the same for dense matrices, for consistency
+"""
+
+# Authors: Marina Meila <mmp@stat.washington.edu>
+#         James McQueen <jmcq@u.washington.edu>
+# License: BSD 3 clause
+from __future__ import division ## removes integer division
+import numpy as np
+from scipy import sparse
+from .distance import compute_adjacency_matrix
+from .affinity import compute_affinity_matrix
+from .laplacian import compute_laplacian_matrix
+from ..utils.validation import check_array
+
+sparse_formats = ['csr', 'coo', 'lil', 'bsr', 'dok', 'dia']
+adjacency_methods = ['auto', 'brute', 'cyflann', 'pyflann', 'cython']
+affintity_methods = ['auto', 'gaussian']
+laplacian_types = ['symmetricnormalized', 'geometric', 'renormalized', 'unnormalized', 'randomwalk']
+distance_error_msg = ("No data matrix exists. "
+                      "Adjacency matrix cannot be computed.")
+affinity_error_msg = ("No data or adjacency matrix exists."
+                      "Affinity matrix cannot be calculated.")
+
+class Geometry(object):
+    """
+    The Geometry class stores the data, distance, affinity and laplacian
+    matrices used by the various embedding methods and is the primary
+    object passed to embedding functions.
+
+    The Geometry class contains functions to compute the aforementioned
+    matrices and allows for re-computation whenever necessary.
+
+    Parameters
+    ----------
+    adjacency_method : string, one of 'auto', 'brute', 'pyflann', 'cyflann'.
+        method for computing pairwise radius neighbors graph.
+    adjacency_kwds : dictionary containing keyword arguments for adjacency matrix.
+        see distance.py docmuentation for arguments for each method.
+    affinity_method : string, one of 'auto', 'gaussian'.
+    affinity_kwds : dictionary containing keyword arguments for affinity matrix.
+        see affinity.py docmuentation for arguments for each method.
+    laplacian_method : string, one of: 'symmetricnormalized', 'geometric', 'renormalized',
+        'unnormalized', 'randomwalk' type of laplacian to be computed. 
+        see laplacian.py for more information.
+    laplacian_kwds : dictionary containing keyword arguments for Laplacian matrix.
+        see laplacian.py docmuentation for arguments for each method.  
+    """
+    def __init__(self, adjacency_method = 'auto', adjacency_kwds=None,
+                 affinity_method = 'auto', affinity_kwds=None,
+                 laplacian_method = 'auto',laplacian_kwds=None):
+        self.adjacency_method = adjacency_method
+        self.adjacency_kwds = adjacency_kwds
+        self.affinity_method = affinity_method
+        self.affinity_kwds = affinity_kwds
+        self.laplacian_method = laplacian_method
+        self.laplacian_kwds = laplacian_kwds
+        
+        self.X = None
+        self.adjacency_matrix = None
+        self.affinity_matrix = None
+        self.laplacian_matrix = None
+        
+    def compute_adjacency_matrix(self, copy = False, **kwargs):
+        """
+        Note: this function will compute the adjacency matrix. In order to acquire
+            the existing adjacency matrix use self.adjacency_matrix as 
+            comptute_adjacency_matrix() will re-compute the adjacency matrix.
+        
+        Parameters
+        ----------
+        copy : boolean, whether to return a copied version of the adjacency matrix
+        **kwargs : see distance.py docmuentation for arguments for each method.
+        
+        Returns
+        -------
+        self.adjacency_matrix : sparse Ndarray (N_obs, N_obs). Non explicit 0.0 values
+            (e.g. diagonal) should be considered Infinite.
+        """
+        if (self.X is None):
+            raise ValueError(distance_error_msg)
+        
+        if self.adjacency_kwds is not None:
+            kwds = self.adjacency_kwds.copy()
+            kwds.update(kwargs)
+        else:
+            kwds = kwargs
+        self.adjacency_matrix = compute_adjacency_matrix(self.X, self.adjacency_method, **kwds)
+        if copy:
+            return self.adjacency_matrix.copy()
+        else:
+            return self.adjacency_matrix
+
+    def compute_affinity_matrix(self, copy = False, **kwargs):
+        """
+        Note: this function will compute the affinity matrix. In order to acquire
+            the existing affinity matrix use self.affinity_matrix as 
+            comptute_affinity_matrix() will re-compute the affinity matrix.
+        
+        Parameters
+        ----------
+        copy : boolean, whether to return a copied version of the affinity matrix
+        **kwargs : see affinity.py docmuentation for arguments for each method.
+
+        Returns
+        -------
+        self.affinity_matrix : sparse Ndarray (N_obs, N_obs) contains the pairwise
+            affinity values using the Guassian kernel and bandwidth equal to the
+            affinity_radius
+        """
+        if (self.X is None and self.adjacency_matrix is None):
+            raise ValueError(affinity_error_msg)
+            
+        if self.affinity_kwds is not None:
+            kwds = self.affinity_kwds.copy()
+            kwds.update(kwargs)
+        else:
+            kwds = kwargs
+        if self.adjacency_matrix is None: # first check to see if we have the distance matrix                
+                self.adjacency_matrix = self.compute_adjacency_matrix()
+        self.affinity_matrix = compute_affinity_matrix(self.adjacency_matrix, 
+                                                       self.affinity_method, **kwds)
+        if copy:
+            return self.affinity_matrix.copy()
+        else:
+            return self.affinity_matrix
+
+    def compute_laplacian_matrix(self, copy=True, return_lapsym=False, **kwargs):
+        """
+        Note: this function will compute the laplacian matrix. In order to acquire
+            the existing laplacian matrix use self.laplacian_matrix as 
+            comptute_laplacian_matrix() will re-compute the laplacian matrix.
+        
+        Parameters
+        ----------
+        copy : boolean, whether to return copied version of the self.laplacian_matrix
+        return_lapsym : boolean, if True returns additionally the symmetrized version of
+            the requested laplacian and the re-normalization weights.
+        **kwargs : see laplacian.py docmuentation for arguments for each method.
+
+        Returns
+        -------
+        self.laplacian_matrix : sparse Ndarray (N_obs, N_obs). The requested laplacian.
+        self.laplacian_symmetric : sparse Ndarray (N_obs, N_obs). The symmetric laplacian.
+        self.w : Ndarray (N_obs). The renormalization weights used to make
+            laplacian_matrix from laplacian_symmetric
+        """
+        if self.laplacian_kwds is not None:
+            kwds = self.laplacian_kwds.copy()
+            kwds.update(kwargs)
+        else:
+            kwds = kwargs
+        
+        if 'return_lapsym' not in kwds.keys():
+            kwds['return_lapsym'] = return_lapsym
+        
+        if self.affinity_matrix is None: # first check to see if we have an affinity matrix
+            self.affinity_matrix = self.get_affinity_matrix(copy=False)
+
+        if return_lapsym:
+            (self.laplacian_matrix,
+            self.laplacian_symmetric,
+            self.w) = compute_laplacian_matrix(self.affinity_matrix, 
+                                               self.laplacian_method,**kwds)
+        else:
+            self.laplacian_matrix = compute_laplacian_matrix(self.affinity_matrix,
+                                                    self.laplacian_method,**kwds)
+        if copy:
+            return self.laplacian_matrix.copy()
+        else:
+            return self.laplacian_matrix
+
+    def set_data_matrix(self, X):
+        """
+        Parameters
+        ----------
+        X : ndarray (N_obs, N_features). The original data set to input.
+        """
+        X = check_array(X, accept_sparse = sparse_formats)
+        self.X = X
+
+    def set_adjacency_matrix(self, adjacency_mat):
+        """
+        Parameters
+        ----------
+        adjacency_mat : sparse Ndarray (N_obs, N_obs). The adjacency matrix to input.
+        """
+        adjacency_mat = check_array(adjacency_mat, accept_sparse = sparse_formats)
+        (a, b) = adjacency_mat.shape
+        if a != b:
+            raise ValueError("adjacency matrix is not square")
+        else:
+            self.adjacency_matrix = adjacency_mat
+
+    def set_affinity_matrix(self, affinity_mat):
+        """
+        Parameters
+        ----------
+        affinity_mat : sparse Ndarray (N_obs, N_obs). The adjacency matrix to input.
+        """
+        affinity_mat = check_array(affinity_mat, accept_sparse = sparse_formats)
+        (a, b) = affinity_mat.shape
+        if a != b:
+            raise ValueError("affinity matrix is not square")
+        else:
+            self.affinity_matrix = affinity_mat
+
+    def set_laplacian_matrix(self, laplacian_mat):
+        """
+        Parameters
+        ----------
+        laplacian_mat : sparse Ndarray (N_obs, N_obs). The Laplacian matrix to input.
+        """
+        laplacian_mat = check_array(laplacian_mat, accept_sparse = sparse_formats)
+        (a, b) = laplacian_mat.shape
+        if a != b:
+            raise ValueError("Laplacian matrix is not square")
+        else:
+            self.laplacian_matrix = laplacian_mat

--- a/megaman/geometry/laplacian.py
+++ b/megaman/geometry/laplacian.py
@@ -1,4 +1,271 @@
+from __future__ import division ## removes integer division
+import numpy as np
+from scipy import sparse
+from scipy.spatial.distance import pdist
+import subprocess, os, sys, warnings
 
 
 def compute_laplacian_matrix(affinity_matrix, method, **kwargs):
-    pass
+    return graph_laplacian(affinity_matrix, method, **kwargs)
+
+###############################################################################
+# Graph laplacian
+# Code adapted from the Matlab function laplacian.m of Dominique Perrault-Joncas
+def graph_laplacian(csgraph, normed = 'geometric', symmetrize = False,
+                    scaling_epps = 0., renormalization_exponent = 1,
+                    return_diag = False, return_lapsym = False):
+    """
+    Return the Laplacian matrix of an undirected graph.
+
+    Computes a consistent estimate of the Laplace-Beltrami operator L
+    from the similarity matrix A . See "Diffusion Maps" (Coifman and
+    Lafon, 2006) and "Graph Laplacians and their Convergence on Random
+    Neighborhood Graphs" (Hein, Audibert, Luxburg, 2007) for more
+    details.
+
+    A is the similarity matrix from the sampled data on the manifold M.
+    Typically A is obtained from the data X by applying the heat kernel
+    A_ij = exp(-||X_i-X_j||^2/EPPS). The bandwidth EPPS of the kernel is
+    need to obtained the properly scaled version of L. Following the usual
+    convention, the laplacian (Laplace-Beltrami operator) is defined as
+    div(grad(f)) (that is the laplacian is taken to be negative
+    semi-definite).
+
+    Note that the Laplacians defined here are the negative of what is
+    commonly used in the machine learning literature. This convention is used
+    so that the Laplacians converge to the standard definition of the
+    differential operator.
+
+    notation: A = csgraph, D=diag(A1) the diagonal matrix of degrees
+    L = lap = returned object, EPPS = scaling_epps**2
+
+    Parameters
+    ----------
+    csgraph : array_like or sparse matrix, 2 dimensions
+        compressed-sparse graph, with shape (N, N).
+    normed : string, optional
+        if 'renormalized':
+            compute renormalized Laplacian of Coifman & Lafon
+            L = D**-alpha A D**-alpha
+            T = diag(L1)
+            L = T**-1 L - eye()
+        if 'symmetricnormalized':
+           compute normalized Laplacian
+            L = D**-0.5 A D**-0.5 - eye()
+        if 'unnormalized': compute unnormalized Laplacian.
+            L = A-D
+        if 'randomwalks': compute stochastic transition matrix
+            L = D**-1 A
+    symmetrize: bool, optional
+        if True symmetrize adjacency matrix (internally) before computing lap
+    scaling_epps: float, optional
+        if >0., it should be the same neighbors_radius that was used as kernel
+        width for computing the affinity. The Laplacian gets the scaled by
+        4/np.sqrt(scaling_epps) in order to ensure consistency in the limit
+        of large N
+    return_diag : bool, optional (kept for compatibility)
+        If True, then return diagonal as well as laplacian.
+    return_lapsym : bool, optional
+        If normed in { 'geometric', 'renormalized' } then a symmetric matrix
+        lapsym, and a row normalization vector w are also returned. Having
+        these allows us to compute the laplacian spectral decomposition
+        as a symmetric matrix, which has much better numerical properties.
+
+    Returns
+    -------
+    lap : ndarray
+        The N x N laplacian matrix of graph.
+    diag : ndarray (obsolete, for compatibiility)
+        The length-N diagonal of the laplacian matrix.
+        diag is returned only if return_diag is True.
+
+    Notes
+    -----
+    There are a few differences from the sklearn.spectral_embedding laplacian
+    function.
+
+    1. normed='unnormalized' and 'symmetricnormalized' correspond respectively
+       to normed=False and True in the latter. (Note also that normed was changed
+       from bool to string.
+    2. the signs of this laplacians are changed w.r.t the original
+    3. the diagonal of lap is no longer set to 0; also there is no checking if
+       the matrix has zeros on the diagonal. If the degree of a node is 0, this
+       is handled graciuously (by not dividing by 0).
+    4. if csgraph is not symmetric the out-degree is used in the
+       computation and no warning is raised. However, it is not recommended to
+       use this function for directed graphs.
+    """
+    if csgraph.ndim != 2 or csgraph.shape[0] != csgraph.shape[1]:
+        raise ValueError('csgraph must be a square matrix or array')
+
+    normed_options = ['unnormalized', 'geometric', 'randomwalk',
+                      'symmetricnormalized', 'renormalized']
+    normed = normed.lower()
+    if normed.lower() not in normed_options:
+        raise ValueError('normed must be one of {0}'.format(normed_options))
+
+    if np.issubdtype(csgraph.dtype, np.integer):
+        csgraph = csgraph.astype(np.float)
+
+    if sparse.isspmatrix(csgraph):
+        return _laplacian_sparse(csgraph, normed=normed,
+                                 symmetrize=symmetrize,
+                                 scaling_epps=scaling_epps,
+                                 renormalization_exponent=renormalization_exponent,
+                                 return_diag=return_diag,
+                                 return_lapsym=return_lapsym)
+
+    else:
+        return _laplacian_dense(csgraph, normed=normed,
+                                symmetrize=symmetrize,
+                                scaling_epps=scaling_epps,
+                                renormalization_exponent=renormalization_exponent,
+                                return_diag=return_diag,
+                                return_lapsym=return_lapsym)
+
+
+def _laplacian_sparse(csgraph, normed='geometric', symmetrize=True,
+                      scaling_epps=0., renormalization_exponent=1,
+                      return_diag=False, return_lapsym=False):
+    n_nodes = csgraph.shape[0]
+    lap = csgraph.copy()
+    if symmetrize:
+        if lap.format is not 'csr':
+            lap.tocsr()
+        lap = (lap + lap.T)/2.
+    if lap.format is not 'coo':
+        lap = lap.tocoo()
+    diag_mask = (lap.row == lap.col)  # True/False
+    degrees = np.asarray(lap.sum(axis=1)).squeeze()
+
+    if normed == 'symmetricnormalized':
+        w = np.sqrt(degrees)
+        w_zeros = (w == 0)
+        w[w_zeros] = 1
+        lap.data /= w[lap.row]
+        lap.data /= w[lap.col]
+        lap.data[diag_mask] -= 1.
+        if return_lapsym:
+            lapsym = lap.copy()
+
+    elif normed == 'geometric':
+        w = degrees.copy()     # normzlize one symmetrically by d
+        w_zeros = (w == 0)
+        w[w_zeros] = 1
+        lap.data /= w[lap.row]
+        lap.data /= w[lap.col]
+        w = np.asarray(lap.sum(axis=1)).squeeze() #normalize again asymmetricall
+        if return_lapsym:
+            lapsym = lap.copy()
+        lap.data /= w[lap.row]
+        lap.data[diag_mask] -= 1.
+
+    elif normed == 'renormalized':
+        w = degrees**renormalization_exponent;
+        # same as 'geometric' from here on
+        w_zeros = (w == 0)
+        w[w_zeros] = 1
+        lap.data /= w[lap.row]
+        lap.data /= w[lap.col]
+        w = np.asarray(lap.sum(axis=1)).squeeze() #normalize again asymmetricall
+        if return_lapsym:
+            lapsym = lap.copy()
+        lap.data /= w[lap.row]
+        lap.data[diag_mask] -= 1.
+
+    elif normed == 'unnormalized':
+        lap.data[diag_mask] -= degrees
+        if return_lapsym:
+            lapsym = lap.copy()
+
+    elif normed == 'randomwalk':
+        w = degrees.copy()
+        if return_lapsym:
+            lapsym = lap.copy()
+        lap.data /= w[lap.row]
+        lap.data[diag_mask] -= 1.
+
+    if scaling_epps > 0.:
+        lap.data *= 4/(scaling_epps**2)
+
+    if return_diag:
+        if return_lapsym:
+            return lap, lap.data[diag_mask], lapsym, w
+        else:
+            return lap, lap.data[diag_mask]
+
+    elif return_lapsym:
+        return lap, lapsym, w
+    else:
+        return lap
+
+
+def _laplacian_dense(csgraph, normed='geometric', symmetrize=True,
+                     scaling_epps=0., renormalization_exponent=1,
+                     return_diag=False, return_lapsym=False):
+    n_nodes = csgraph.shape[0]
+    if symmetrize:
+        lap = (csgraph + csgraph.T)/2.
+    else:
+        lap = csgraph.copy()
+    degrees = np.asarray(lap.sum(axis=1)).squeeze()
+    di = np.diag_indices( lap.shape[0] )  # diagonal indices
+
+    if normed == 'symmetricnormalized':
+        w = np.sqrt(degrees)
+        w_zeros = (w == 0)
+        w[w_zeros] = 1
+        lap /= w
+        lap /= w[:, np.newaxis]
+        di = np.diag_indices( lap.shape[0] )
+        lap[di] -= (1 - w_zeros).astype(lap.dtype)
+        if return_lapsym:
+            lapsym = lap.copy()
+    elif normed == 'geometric':
+        w = degrees.copy()     # normalize once symmetrically by d
+        w_zeros = (w == 0)
+        w[w_zeros] = 1
+        lap /= w
+        lap /= w[:, np.newaxis]
+        w = np.asarray(lap.sum(axis=1)).squeeze() #normalize again asymmetricall
+        if return_lapsym:
+            lapsym = lap.copy()
+        lap /= w[:, np.newaxis]
+        lap[di] -= (1 - w_zeros).astype(lap.dtype)
+    elif normed == 'renormalized':
+        w = degrees**renormalization_exponent;
+        # same as 'geometric' from here on
+        w_zeros = (w == 0)
+        w[w_zeros] = 1
+        lap /= w
+        lap /= w[:, np.newaxis]
+        w = np.asarray(lap.sum(axis=1)).squeeze() #normalize again asymmetricall
+        if return_lapsym:
+            lapsym = lap.copy()
+        lap /= w[:, np.newaxis]
+        lap[di] -= (1 - w_zeros).astype(lap.dtype)
+    elif normed == 'unnormalized':
+        dum = lap[di]-degrees[np.newaxis,:]
+        lap[di] = dum[0,:]
+        if return_lapsym:
+            lapsym = lap.copy()
+    elif normed == 'randomwalk':
+        w = degrees.copy()
+        if return_lapsym:
+            lapsym = lap.copy()
+        lap /= w[:,np.newaxis]
+        lap -= np.eye(lap.shape[0])
+
+    if scaling_epps > 0.:
+        lap *= 4/(scaling_epps**2)
+
+    if return_diag:
+        diag = np.array( lap[di] )
+        if return_lapsym:
+            return lap, diag, lapsym, w
+        else:
+            return lap, diag
+    elif return_lapsym:
+        return lap, lapsym, w
+    else:
+        return lap

--- a/megaman/geometry/tests/test_geometry_new.py
+++ b/megaman/geometry/tests/test_geometry_new.py
@@ -1,0 +1,118 @@
+from __future__ import division ## removes integer division
+
+import warnings
+import numpy as np
+from scipy import sparse
+from numpy.testing import assert_array_almost_equal
+from scipy.spatial.distance import pdist, squareform
+from megaman.geometry.geometry_new import *
+import megaman.geometry.geometry_new as geom
+from megaman.utils.testing import assert_raise_message
+from megaman.geometry.distance import distance_matrix
+from megaman.geometry.geometry_new import laplacian_types
+from megaman.geometry.laplacian import *
+from megaman.geometry.affinity import *
+
+def test_compare_adjacency_methods(almost_equal_decimals=5):
+    """ compare the different adjacency methods """
+    X = np.random.uniform(size=(20,2))
+    D = squareform(pdist(X))
+    radius = 1.
+    D[D>radius]=0
+    for adjacency_method in adjacency_methods:
+        G = geom.Geometry(adjacency_method = 'brute')
+        G.set_data_matrix(X)
+        d = G.compute_adjacency_matrix(radius=radius)
+        assert_array_almost_equal(D, d.todense(), almost_equal_decimals)
+
+def test_compute_adjacency_matrix_args(almost_equal_decimals=5):
+    """ test the compute_adjacency_matrix parameter arguments """
+    input_types = ['data', 'adjacency', 'affinity']
+    params = [{}, {'radius':1}, {'radius':2}]    
+    for adjacency_method in adjacency_methods:
+        X = np.random.uniform(size=(10, 2))
+        D = compute_adjacency_matrix(X, adjacency_method, **params[1])
+        A = compute_affinity_matrix(D, method = 'auto')
+        for init_params in params:
+            for kwarg_params in params:
+                true_params = init_params.copy()
+                true_params.update(kwarg_params)
+                adjacency_true = compute_adjacency_matrix(X, adjacency_method, **true_params)
+                G = geom.Geometry(adjacency_method = adjacency_method, adjacency_kwds = init_params)
+                for input in input_types:
+                    G = geom.Geometry(adjacency_kwds = init_params)
+                    if input in ['data']:  
+                        G.set_data_matrix(X)
+                        adjacency_queried = G.compute_adjacency_matrix(**kwarg_params)
+                        assert_array_almost_equal(adjacency_true.todense(), adjacency_queried.todense(), 
+                                                  almost_equal_decimals)
+                    else:
+                        if input in ['adjacency']:
+                            G.set_adjacency_matrix(D)
+                        else:
+                            G.set_affinity_matrix(A)
+                        msg = distance_error_msg
+                        assert_raise_message(ValueError, msg, G.compute_adjacency_matrix)
+
+def test_compute_affinity_matrix_args(almost_equal_decimals=5):
+    """ test the compute_adjacency_matrix parameter arguments """
+    input_types = ['data', 'adjacency', 'affinity']
+    params = [{}, {'radius':4}, {'radius':5}]
+    adjacency_method = 'auto'    
+    for affinity_method in affinity_methods:
+        X = np.random.uniform(size=(10, 2))
+        D = compute_adjacency_matrix(X, adjacency_method, **params[1])
+        A = compute_affinity_matrix(D, affinity_method, **params[1])
+        for init_params in params:
+            for kwarg_params in params:
+                true_params = init_params.copy()
+                true_params.update(kwarg_params)
+                affinity_true = compute_affinity_matrix(D, adjacency_method, **true_params)
+                for input in input_types:
+                    G = geom.Geometry(adjacency_method = adjacency_method,
+                                      adjacency_kwds = params[1], 
+                                      affinity_method = affinity_method,
+                                      affinity_kwds = init_params)
+                    if input in ['data', 'adjacency']:  
+                        if input in ['data']:
+                            G.set_data_matrix(X)
+                        else:
+                            G.set_adjacency_matrix(D)
+                        affinity_queried = G.compute_affinity_matrix(**kwarg_params)
+                        assert_array_almost_equal(affinity_true.todense(), affinity_queried.todense(), almost_equal_decimals)
+                    else:
+                        G.set_affinity_matrix(A)
+                        msg = affinity_error_msg
+                        assert_raise_message(ValueError, msg, G.compute_affinity_matrix)
+
+def test_compute_laplacian_matrix_args(almost_equal_decimals=5):
+    input_types = ['data', 'adjacency', 'affinity']
+    params = [{}, {'radius':4}, {'radius':5}]
+    lapl_params = [{}, {'scaling_epps':4}, {'scaling_epps':10}]
+    adjacency_method = 'auto'
+    affinity_method = 'auto'
+    
+    for laplacian_method in laplacian_types:
+        X = np.random.uniform(size=(10, 2))
+        D = compute_adjacency_matrix(X, adjacency_method, **params[1])
+        A = compute_affinity_matrix(D, affinity_method, **params[1])
+        for init_params in lapl_params:
+            for kwarg_params in lapl_params:
+                    true_params = init_params.copy()
+                    true_params.update(kwarg_params)
+                    laplacian_true = compute_laplacian_matrix(A, laplacian_method, **true_params)
+            for input in input_types:
+                G = geom.Geometry(adjacency_method = adjacency_method,
+                                  adjacency_kwds = params[1], 
+                                  affinity_method = affinity_method,
+                                  affinity_kwds = params[1],
+                                  laplacian_method = laplacian_method,
+                                  laplacian_kwds = lapl_params[0])
+                if input in ['data']:
+                    G.set_data_matrix(X)
+                if input in ['adjacency']:
+                    G.set_adjacency_matrix(D)
+                else:
+                    G.set_affinity_matrix(A)
+                laplacian_queried = G.compute_laplacian_matrix(**kwarg_params)
+                assert_array_almost_equal(laplacian_true.todense(), laplacian_queried.todense(), almost_equal_decimals)


### PR DESCRIPTION
Geometry class implemented in geometry_new

- init() changed to accept 3 method arguments & dictionary arguments: adjacency, affinity, laplacian
- adjacency, affinity, laplacian compute, set & delete functions. 
- compute functions adjusted to work with the general: \*_matrix(graph, method, **kwargs)

accepted parameters & error messages moved to the top. 

test_geometry_new.py for loops through possible combinations and checks that the correct parameters are being calculated. 

Changes to distance.py, affinity.py, & laplacian.py are to temporary to work with \*_matrix(graph, method, **kwargs)