### PR TITLE
MAINT: switch travis script to installing from conda-forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     # Directory where tests are run from
     - TEST_DIR=/tmp/megaman
-    - CONDA_CHANNEL="https://conda.anaconda.org/jakevdp"
+    - CONDA_CHANNEL="conda-forge"
     - CONDA_DEPS="pip nose coverage cython scikit-learn flann"
     - PIP_DEPS="coveralls"
   matrix:


### PR DESCRIPTION
I put a megaman build on conda-forge; this changes the travis tests to use that for installation of dependencies.