### PR TITLE
fixing Python 3.4/3.5 bug with index_type passed as str instead of byte

### DIFF
--- a/megaman/geometry/cyflann/index.pyx
+++ b/megaman/geometry/cyflann/index.pyx
@@ -38,6 +38,7 @@ cdef class Index:
             self._thisptr = new CyflannIndex(dataset.flatten(),
                     dataset.shape[1], saved_index)
         elif index_type is not None:
+            index_type = index_type.encode('utf-8')
             self._thisptr = new CyflannIndex(dataset.flatten(),
                     dataset.shape[1], index_type, num_trees, branching,
                     iterations, cb_index)

--- a/megaman/geometry/tests/test_adjacency.py
+++ b/megaman/geometry/tests/test_adjacency.py
@@ -117,3 +117,20 @@ def test_custom_adjacency():
     assert_allclose(D, cdist(X, X))
 
     Adjacency._remove_from_registry("custom")
+
+def test_cyflann_index_type():
+    rand = np.random.RandomState(36)
+    X = rand.randn(10, 2)
+    D_true = squareform(pdist(X))
+    D_true[D_true > 1.5] = 0
+    
+    def check_index_type(index_type):
+        method = 'cyflann'
+        radius = 1.5
+        cyflann_kwds = {'index_type':index_type}
+        adjacency_kwds = {'radius':radius, 'cyflann_kwds':cyflann_kwds}
+        this_D = compute_adjacency_matrix(X=X, method = 'cyflann', **adjacency_kwds)
+        assert_allclose(this_D.toarray(), D_true, rtol=1E-5)
+    
+    for index_type in ['kmeans', 'kdtrees']:
+        yield check_index_type, index_type


### PR DESCRIPTION
Python 3.4 and 3.5 have an issue where index_type parameter passed as a string is not accepted. 