### PR TITLE
Spectral Embedding Predict Function

### DIFF
--- a/megaman/embedding/tests/test_spectral_embedding.py
+++ b/megaman/embedding/tests/test_spectral_embedding.py
@@ -235,7 +235,7 @@ def test_predict_size(seed=36):
         radius = 4.0
         geom_params = {'affinity_kwds':{'radius':radius}, 'adjacency_kwds':{'radius':radius}, 'adjacency_method':'brute',
                     'laplacian_method':'geometric'}
-        se = SpectralEmbedding(n_components=2,eigen_solver="amg",
+        se = SpectralEmbedding(n_components=2,eigen_solver="arpack",
                                random_state=np.random.RandomState(seed), geom = geom_params)
         S_train = S[:900,:]
         S_test = S[-100:, :]

--- a/megaman/embedding/tests/test_spectral_embedding.py
+++ b/megaman/embedding/tests/test_spectral_embedding.py
@@ -227,3 +227,17 @@ def test_connectivity(seed=36):
     assert_equal(_graph_is_connected(graph), True)
     assert_equal(_graph_is_connected(csr_matrix(graph)), True)
     assert_equal(_graph_is_connected(csc_matrix(graph)), True)
+
+def test_predict_size(seed=36):
+    """Test the predict function returns appropriate size data"""
+    # test that it returns values of the appropriate shape
+    # test both with and without diffusion maps
+    assert(True)
+    
+def test_predict_error_not_fitted():
+    """ Test predict function raises an error when .fit() has not been called"""
+    assert(True)
+
+def test_predict_error_no_data():
+    """ Test predict raises an error when X is originally passed as adjacency or affinity"""
+    assert(True)

--- a/megaman/embedding/tests/test_spectral_embedding.py
+++ b/megaman/embedding/tests/test_spectral_embedding.py
@@ -262,7 +262,7 @@ def test_predict_error_not_fitted(seed=36):
     assert_raise_message(RuntimeError, msg, se.predict, S_test)
 
 def test_predict_error_no_data(seed=36):
-    """ Test predict raises an error when data X are not passed"
+    """ Test predict raises an error when data X are not passed"""
     radius = 4.0
     se = SpectralEmbedding(n_components=2,
                            random_state=np.random.RandomState(seed))

--- a/megaman/embedding/tests/test_spectral_embedding.py
+++ b/megaman/embedding/tests/test_spectral_embedding.py
@@ -19,6 +19,7 @@ import megaman.geometry.geometry as geom
 
 from sklearn.metrics import normalized_mutual_info_score
 from sklearn.datasets.samples_generator import make_blobs
+from megaman.utils.testing import assert_raise_message
 
 
 # non centered, sparse centers to check the
@@ -230,14 +231,46 @@ def test_connectivity(seed=36):
 
 def test_predict_size(seed=36):
     """Test the predict function returns appropriate size data"""
-    # test that it returns values of the appropriate shape
-    # test both with and without diffusion maps
-    assert(True)
+    def check_size(diffusion_maps):
+        radius = 4.0
+        geom_params = {'affinity_kwds':{'radius':radius}, 'adjacency_kwds':{'radius':radius}, 'adjacency_method':'brute',
+                    'laplacian_method':'geometric'}
+        se = SpectralEmbedding(n_components=2,eigen_solver="amg",
+                               random_state=np.random.RandomState(seed), geom = geom_params)
+        S_train = S[:900,:]
+        S_test = S[-100:, :]
+        embed_train= se.fit_transform(S_train)
+        embed_test, embed_total = se.predict(S_test)
+        assert(embed_test.shape[0] == S_test.shape[0])
+        assert(embed_test.shape[1] == embed_train.shape[1])
+        assert(embed_total.shape[0] == S.shape[0])
+        assert(embed_total.shape[1] == embed_train.shape[1])
     
-def test_predict_error_not_fitted():
-    """ Test predict function raises an error when .fit() has not been called"""
-    assert(True)
+    for diffusion_maps in [False, True]:
+        yield check_size, diffusion_maps
 
-def test_predict_error_no_data():
-    """ Test predict raises an error when X is originally passed as adjacency or affinity"""
-    assert(True)
+def test_predict_error_not_fitted(seed=36):
+    """ Test predict function raises an error when .fit() has not been called"""
+    radius = 4.0
+    geom_params = {'affinity_kwds':{'radius':radius}, 'adjacency_kwds':{'radius':radius}, 'adjacency_method':'brute',
+                'laplacian_method':'geometric'}
+    se = SpectralEmbedding(n_components=2,eigen_solver="amg",
+                           random_state=np.random.RandomState(seed), geom = geom_params)
+    S_train = S[:900,:]
+    S_test = S[-100:, :]
+    msg = 'the .fit() function must be called before the .predict() function'
+    assert_raise_message(RuntimeError, msg, se.predict, S_test)
+
+def test_predict_error_no_data(seed=36):
+    """ Test predict raises an error when data X are not passed"
+    radius = 4.0
+    se = SpectralEmbedding(n_components=2,
+                           random_state=np.random.RandomState(seed))
+    G = geom.Geometry(adjacency_method = 'brute', adjacency_kwds = {'radius':radius},
+                      affinity_kwds = {'radius':radius})
+    G.set_data_matrix(S)
+    S_test = S[-100:, :]
+    A = G.compute_affinity_matrix()
+    embed = se.fit_transform(A, input_type = 'affinity')
+    msg = 'method only implemented when X passed as data'
+    assert_raise_message(NotImplementedError, msg, se.predict, S_test)

--- a/megaman/embedding/tests/test_spectral_embedding.py
+++ b/megaman/embedding/tests/test_spectral_embedding.py
@@ -254,7 +254,7 @@ def test_predict_error_not_fitted(seed=36):
     radius = 4.0
     geom_params = {'affinity_kwds':{'radius':radius}, 'adjacency_kwds':{'radius':radius}, 'adjacency_method':'brute',
                 'laplacian_method':'geometric'}
-    se = SpectralEmbedding(n_components=2,eigen_solver="amg",
+    se = SpectralEmbedding(n_components=2,eigen_solver="arpack",
                            random_state=np.random.RandomState(seed), geom = geom_params)
     S_train = S[:900,:]
     S_test = S[-100:, :]

--- a/megaman/geometry/adjacency.py
+++ b/megaman/geometry/adjacency.py
@@ -101,7 +101,7 @@ class CyFLANNAdjacency(Adjacency):
 
 
     def build_index(self, X):
-        return _get_built_index(X)
+        return self._get_built_index(X)
 
 
     def radius_adjacency(self, index, queries):

--- a/megaman/geometry/complete_adjacency_matrix.py
+++ b/megaman/geometry/complete_adjacency_matrix.py
@@ -1,0 +1,14 @@
+from .adjacency import CyFLANNAdjacency, compute_adjacency_matrix
+from scipy.sparse import vstack, hstack
+
+def complete_adjacency_matrix(Dtrain, Xtrain, Xtest, train_index = None, radius=None, **kwargs):
+    if train_index is None:
+        Cyflann = CyFLANNAdjacency(radius=radius, **kwargs)
+        train_index = Cyflann.build_index(Xtrain)
+    else:
+        Cyflann = CyFLANNAdjacency(radius=radius, flann_index = train_index, **kwargs)        
+    test_train_adjacency = train_index.radius_neighbors_graph(Xtest, radius)
+    test_test_adjacency = compute_adjacency_matrix(Xtest, method='cyflann', radius = radius, **kwargs)    
+    train_adjacency = hstack([Dtrain, test_train_adjacency.transpose()])
+    test_adjacency = hstack([test_train_adjacency, test_test_adjacency])    
+    return vstack([train_adjacency, test_adjacency])

--- a/megaman/geometry/complete_adjacency_matrix.py
+++ b/megaman/geometry/complete_adjacency_matrix.py
@@ -2,14 +2,16 @@
 from .adjacency import CyFLANNAdjacency, compute_adjacency_matrix
 from scipy.sparse import vstack, hstack
 
-def complete_adjacency_matrix(Dtrain, Xtrain, Xtest, train_index = None, radius=None, **kwargs):
-    if train_index is None:
-        Cyflann = CyFLANNAdjacency(radius=radius, **kwargs)
-        train_index = Cyflann.build_index(Xtrain)
+def complete_adjacency_matrix(Dtrain, Xtrain, Xtest, adjacency_kwds):
+    if 'cyflann_kwds' in adjacency_kwds.keys():
+        cyflann_kwds = adjacency_kwds['cyflann_kwds']
     else:
-        Cyflann = CyFLANNAdjacency(radius=radius, flann_index = train_index, **kwargs)        
+        cyflann_kwds = {}
+    radius = adjacency_kwds['radius']
+    Cyflann = CyFLANNAdjacency(radius=radius, **cyflann_kwds)
+    train_index = Cyflann.build_index(Xtrain)
     test_train_adjacency = train_index.radius_neighbors_graph(Xtest, radius)
-    test_test_adjacency = compute_adjacency_matrix(Xtest, method='cyflann', radius = radius, **kwargs)    
+    test_test_adjacency = compute_adjacency_matrix(Xtest, method='cyflann', **adjacency_kwds)    
     train_adjacency = hstack([Dtrain, test_train_adjacency.transpose()])
     test_adjacency = hstack([test_train_adjacency, test_test_adjacency])    
     return vstack([train_adjacency, test_adjacency])

--- a/megaman/geometry/complete_adjacency_matrix.py
+++ b/megaman/geometry/complete_adjacency_matrix.py
@@ -1,3 +1,4 @@
+# LICENSE: Simplified BSD https://github.com/mmp2/megaman/blob/master/LICENSE
 from .adjacency import CyFLANNAdjacency, compute_adjacency_matrix
 from scipy.sparse import vstack, hstack
 

--- a/megaman/geometry/tests/test_complete_adjacency_matrix.py
+++ b/megaman/geometry/tests/test_complete_adjacency_matrix.py
@@ -1,0 +1,20 @@
+from scipy.spatial.distance import cdist, pdist, squareform
+from megaman.geometry.adjacency import compute_adjacency_matrix
+from megaman.geometry.complete_adjacency_matrix import complete_adjacency_matrix
+import numpy as np
+from numpy.testing import assert_allclose
+
+def test_complete_adjacency():
+    rand = np.random.RandomState(36)
+    radius = 1.5
+    X = rand.randn(10, 2)
+    Xtest = rand.randn(4, 2)
+    
+    Xtotal = np.vstack([X, Xtest])
+    D_true = squareform(pdist(Xtotal))
+    D_true[D_true > radius] = 0
+    
+    Dtrain = compute_adjacency_matrix(X, method='cyflann', radius = radius)
+    this_D = complete_adjacency_matrix(Dtrain, X, Xtest, radius = radius)
+    
+    assert_allclose(this_D.toarray(), D_true, rtol=1E-5)

--- a/megaman/geometry/tests/test_complete_adjacency_matrix.py
+++ b/megaman/geometry/tests/test_complete_adjacency_matrix.py
@@ -14,7 +14,8 @@ def test_complete_adjacency():
     D_true = squareform(pdist(Xtotal))
     D_true[D_true > radius] = 0
     
+    adjacency_kwds = {'radius':radius}
     Dtrain = compute_adjacency_matrix(X, method='cyflann', radius = radius)
-    this_D = complete_adjacency_matrix(Dtrain, X, Xtest, radius = radius)
+    this_D = complete_adjacency_matrix(Dtrain, X, Xtest, adjacency_kwds)
     
-    assert_allclose(this_D.toarray(), D_true, rtol=1E-5)
+    assert_allclose(this_D.toarray(), D_true, rtol=1E-4)

--- a/megaman/utils/nystrom_extension.py
+++ b/megaman/utils/nystrom_extension.py
@@ -7,6 +7,8 @@ Created on Tue Jun 21 11:11:40 2016
 """
 from __future__ import division 
 import numpy as np
+import warnings
+from scipy.sparse import isspmatrix
 def nystrom_extension(C, e_vec, e_val):
     """
     Parameters
@@ -30,15 +32,18 @@ def nystrom_extension(C, e_vec, e_val):
       These are the corresponding eig vectors to eval_nystrom
       
     """
-    n,l = C.shape    
+    n,l = C.shape
     W = C[0:l, :]
     eval_nystrom = (n/l)*e_val
     eval_inv = e_val.copy()
-    e_nonzero = [i for i, e in enumerate(e_val) if e != 0] #np.nonzero(a)[0]
+    e_nonzero = np.where(e_val != 0)
+    # e_nonzero = [i for i, e in enumerate(e_val) if e != 0] #np.nonzero(a)[0]
     eval_inv[e_nonzero] = 1.0/e_val[e_nonzero]
     
-    evec_nystrom = np.dot(C,e_vec)*eval_inv
-    evec_nystrom = np.sqrt(l/n)*evec_nystrom
+    if isspmatrix(C):
+        evec_nystrom = np.sqrt(l/n)*C.dot(e_vec)*eval_inv
+    else:
+        evec_nystrom = np.sqrt(l/n)*np.dot(C,e_vec)*eval_inv
     return eval_nystrom,evec_nystrom
     
     

--- a/megaman/utils/nystrom_extension.py
+++ b/megaman/utils/nystrom_extension.py
@@ -1,3 +1,4 @@
+# LICENSE: Simplified BSD https://github.com/mmp2/megaman/blob/master/LICENSE
 # -*- coding: utf-8 -*-
 """
 Created on Tue Jun 21 11:11:40 2016

--- a/megaman/utils/tests/test_nystrom.py
+++ b/megaman/utils/tests/test_nystrom.py
@@ -9,7 +9,7 @@ def test_nystrom_extension(seed=123):
     """ Test Nystrom Extension: low rank approximation is exact when
     G is itself low rank
     """
-    n = 5
+    n = 10
     s = 2
     rng = np.random.RandomState(seed)
     X = rng.randn(n, s)


### PR DESCRIPTION
Spectral embedding now has a .predict() function.

This function computes the remainder of the adjacency, affinity, and Laplacian matrices using the known matrices on training data plus test data.

The eigendecomposition is then *estimated* via the Nystrom extension. This extends the algorithm to test data without re-computing the eigendecomposition on the full matrix.

The adjacency must be computed in full due to normalization in the Laplacian. 