### PR TITLE
Integration of Fraunhofer SAMG as an alternative to PyAMG

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To install megaman from source requires the following:
 Optional requirements include
 
 - [pyamg](http://pyamg.org/), which allows for faster decompositions of large matrices
-- [pysamg](http://sca i.fraunhofer.de/samg/), which allows for even faster decompositions of large matrices. This needs and is included in the commercial Fraunhofer SAMG.  For licensing (including test or educational licenses) contact samg@scai.fraunhofer.de
+- [pysamg](http://scai.fraunhofer.de/samg/), which allows for even faster decompositions of large matrices. This needs and is included in the commercial software Fraunhofer SAMG.  For licensing (including test or educational licenses) contact samg@scai.fraunhofer.de
 - [pyflann](http://www.cs.ubc.ca/research/flann/) which offers another method of computing distance matrices (this is bundled with the FLANN source code)
 - [nose](https://nose.readthedocs.org/) for running the unit tests
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ steps and indices to allow for fast re-computation with new parameters.
 
 Package documentation can be found at http://mmp2.github.io/megaman/
 
-If you use our software please cite the following JMLR paper: 
+If you use our software please cite the following JMLR paper:
 
 McQueen, Meila, VanderPlas, & Zhang, "Megaman: Scalable Manifold Learning in Python",
 Journal of Machine Learning Research, Vol 17 no. 14, 2016.
@@ -64,10 +64,11 @@ To install megaman from source requires the following:
 Optional requirements include
 
 - [pyamg](http://pyamg.org/), which allows for faster decompositions of large matrices
+- [pysamg](http://sca i.fraunhofer.de/samg/), which allows for even faster decompositions of large matrices. This needs and is included in the commercial Fraunhofer SAMG.  For licensing (including test or educational licenses) contact samg@scai.fraunhofer.de
 - [pyflann](http://www.cs.ubc.ca/research/flann/) which offers another method of computing distance matrices (this is bundled with the FLANN source code)
 - [nose](https://nose.readthedocs.org/) for running the unit tests
 
-These requirements can be installed on Linux and MacOSX using the following conda command:
+These requirements(except for SAMG) can be installed on Linux and MacOSX using the following conda command:
 
 ```
 $ conda install --channel=conda-forge pip nose coverage gcc cython numpy scipy scikit-learn pyflann pyamg
@@ -91,7 +92,7 @@ to run the unit tests. ``megaman`` is tested on Python versions 2.7, 3.4, and 3.
 - [Zhongyue Zhang](https://github.com/Jerryzcn)
 - [Jake VanderPlas](http://www.vanderplas.com)
 
-## Other Contributors 
+## Other Contributors
 
 - Xiao Wang: lazy rmetric, Nystrom Extension
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -30,10 +30,11 @@ To install ``megaman`` from source requires the following:
 Optional requirements include:
 
 - pyamg_, which provides fast decompositions of large sparse matrices
+- pysamg_, which  provides fast decompositions of large sparse matrices. This needs and is included in the commercial software Fraunhofer SAMG.
 - pyflann_, which offers an alternative FLANN interface for computing distance matrices (this is bundled with the FLANN source code)
 - nose_ for running the unit tests
 
-These requirements can be installed on Linux and MacOSX using the following conda command::
+These requirements (except SAMG) can be installed on Linux and MacOSX using the following conda command::
 
     $ conda install --channel=jakevdp pip nose coverage gcc cython numpy scipy scikit-learn pyflann pyamg
 
@@ -60,6 +61,7 @@ or, outside the source directory once ``megaman`` is installed::
 .. _scikit-learn: http://scikit-learn.org
 .. _FLANN: http://www.cs.ubc.ca/research/flann/
 .. _pyamg: http://pyamg.org/
+.. _pysamg: http://scai.fraunhofer.de/samg/
 .. _pyflann: http://www.cs.ubc.ca/research/flann/
 .. _nose: https://nose.readthedocs.org/
 .. _cython: http://cython.org/

--- a/megaman/embedding/isomap.py
+++ b/megaman/embedding/isomap.py
@@ -34,7 +34,7 @@ def isomap(geom, n_components=8, eigen_solver='auto',
     geom : a Geometry object from megaman.geometry.geometry
     n_components : integer, optional
         The dimension of the projection subspace.
-    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', or 'amg'}
+    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', 'amg' or 'samg'}
         'auto' :
             algorithm will attempt to choose the best method for input data
         'dense' :
@@ -52,9 +52,17 @@ def isomap(geom, n_components=8, eigen_solver='auto',
         'amg' :
             AMG requires pyamg to be installed. It can be faster on very large,
             sparse problems, but may also lead to instabilities.
+        'samg' :
+            Algebraic Multigrid solver from Fraunhofer SCAI (requires
+            ``Fraunhofer SAMG`` and ``pysamg`` to be installed). It can be
+            significantly faster on very large, sparse problems. Note that SAMG
+            is a commercial product and one needs a license to use it. For
+            licensing (including test or educational licenses)
+            contact samg@scai.fraunhofer.de
     random_state : int seed, RandomState instance, or None (default)
         A pseudo random number generator used for the initialization of the
-        lobpcg eigen vectors decomposition when eigen_solver == 'amg'.
+        lobpcg eigen vectors decomposition when eigen_solver == 'amg' or
+        eigen_solver == 'samg'.
         By default, arpack is used.
     path_method : string, method for computing graph shortest path. One of :
         'auto', 'D', 'FW', 'BF', 'J'. See scipy.sparse.csgraph.shortest_path
@@ -125,13 +133,12 @@ class Isomap(BaseEmbedding):
         specification of geometry parameters: keys are
         ["adjacency_method", "adjacency_kwds", "affinity_method",
          "affinity_kwds", "laplacian_method", "laplacian_kwds"]
-    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', or 'amg'}
+    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', 'amg' or 'samg'}
         'auto' :
             algorithm will attempt to choose the best method for input data
         'dense' :
-            use standard dense matrix operations for the eigenvalue
-            decomposition. Uses a dense data array, and thus should be avoided
-            for large problems.
+            use standard dense matrix operations for the eigenvalue decomposition.
+            For this method, M must be an array or matrix type.  This method should be avoided for large problems.
         'arpack' :
             use arnoldi iteration in shift-invert mode. For this method,
             M may be a dense matrix, sparse matrix, or general linear operator.
@@ -144,6 +151,13 @@ class Isomap(BaseEmbedding):
         'amg' :
             AMG requires pyamg to be installed. It can be faster on very large,
             sparse problems, but may also lead to instabilities.
+        'samg' :
+            Algebraic Multigrid solver from Fraunhofer SCAI (requires
+            ``Fraunhofer SAMG`` and ``pysamg`` to be installed). It can be
+            significantly faster on very large, sparse problems. Note that SAMG
+            is a commercial product and one needs a license to use it. For
+            licensing (including test or educational licenses)
+            contact samg@scai.fraunhofer.de
     random_state : numpy.RandomState or int, optional
         The generator or seed used to determine the starting vector for arpack
         iterations.  Defaults to numpy.random.RandomState
@@ -192,17 +206,38 @@ class Isomap(BaseEmbedding):
             Interpret X as precomputed distance or adjacency graph
             computed from samples.
 
-        eigen_solver : {None, 'arpack', 'lobpcg', or 'amg'}
-            The eigenvalue decomposition strategy to use. AMG requires pyamg
-            to be installed. It can be faster on very large, sparse problems,
-            but may also lead to instabilities.
+        eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', 'amg' or 'samg'}
+            'auto' :
+                algorithm will attempt to choose the best method for input data
+            'dense' :
+                use standard dense matrix operations for the eigenvalue decomposition.
+                For this method, M must be an array or matrix type.  This method should be avoided for large problems.
+            'arpack' :
+                use arnoldi iteration in shift-invert mode. For this method,
+                M may be a dense matrix, sparse matrix, or general linear operator.
+                Warning: ARPACK can be unstable for some problems.  It is best to
+                try several random seeds in order to check results.
+            'lobpcg' :
+                Locally Optimal Block Preconditioned Conjugate Gradient Method.
+                A preconditioned eigensolver for large symmetric positive definite
+                (SPD) generalized eigenproblems.
+            'amg' :
+                AMG requires pyamg to be installed. It can be faster on very large,
+                sparse problems, but may also lead to instabilities.
+            'samg' :
+                Algebraic Multigrid solver from Fraunhofer SCAI (requires
+                ``Fraunhofer SAMG`` and ``pysamg`` to be installed). It can be
+                significantly faster on very large, sparse problems. Note that SAMG
+                is a commercial product and one needs a license to use it. For
+                licensing (including test or educational licenses)
+                contact samg@scai.fraunhofer.de
 
         Returns
         -------
         self : object
             Returns the instance itself.
         """
-        
+
         X = self._validate_input(X, input_type)
         self.fit_geometry(X, input_type)
 

--- a/megaman/embedding/locally_linear.py
+++ b/megaman/embedding/locally_linear.py
@@ -70,7 +70,7 @@ def locally_linear_embedding(geom, n_components, reg=1e-3,
     reg : float
         regularization constant, multiplies the trace of the local covariance
         matrix of the distances.
-    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', or 'amg'}
+    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', 'amg' or 'samg'}
         'auto' :
             algorithm will attempt to choose the best method for input data
         'dense' :
@@ -88,6 +88,13 @@ def locally_linear_embedding(geom, n_components, reg=1e-3,
         'amg' :
             AMG requires pyamg to be installed. It can be faster on very large,
             sparse problems, but may also lead to instabilities.
+        'samg' :
+            Algebraic Multigrid solver from Fraunhofer SCAI (requires
+            ``Fraunhofer SAMG`` and ``pysamg`` to be installed). It can be
+            significantly faster on very large, sparse problems. Note that SAMG
+            is a commercial product and one needs a license to use it. For
+            licensing (including test or educational licenses)
+            contact samg@scai.fraunhofer.de
     random_state : numpy.RandomState or int, optional
         The generator or seed used to determine the starting vector for arpack
         iterations.  Defaults to numpy.random.
@@ -143,13 +150,12 @@ class LocallyLinearEmbedding(BaseEmbedding):
         specification of geometry parameters: keys are
         ["adjacency_method", "adjacency_kwds", "affinity_method",
          "affinity_kwds", "laplacian_method", "laplacian_kwds"]
-    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', or 'amg'}
+    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', 'amg' or 'samg'}
         'auto' :
             algorithm will attempt to choose the best method for input data
         'dense' :
-            use standard dense matrix operations for the eigenvalue
-            decomposition. Uses a dense data array, and thus should be avoided
-            for large problems.
+            use standard dense matrix operations for the eigenvalue decomposition.
+            For this method, M must be an array or matrix type.  This method should be avoided for large problems.
         'arpack' :
             use arnoldi iteration in shift-invert mode. For this method,
             M may be a dense matrix, sparse matrix, or general linear operator.
@@ -162,6 +168,13 @@ class LocallyLinearEmbedding(BaseEmbedding):
         'amg' :
             AMG requires pyamg to be installed. It can be faster on very large,
             sparse problems, but may also lead to instabilities.
+        'samg' :
+            Algebraic Multigrid solver from Fraunhofer SCAI (requires
+            ``Fraunhofer SAMG`` and ``pysamg`` to be installed). It can be
+            significantly faster on very large, sparse problems. Note that SAMG
+            is a commercial product and one needs a license to use it. For
+            licensing (including test or educational licenses)
+            contact samg@scai.fraunhofer.de
     random_state : numpy.RandomState or int, optional
         The generator or seed used to determine the starting vector for arpack
         iterations.  Defaults to numpy.random.RandomState

--- a/megaman/embedding/ltsa.py
+++ b/megaman/embedding/ltsa.py
@@ -30,7 +30,7 @@ def ltsa(geom, n_components, eigen_solver='auto',
     geom : a Geometry object from megaman.geometry.geometry
     n_components : integer
         number of coordinates for the manifold.
-    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', or 'amg'}
+    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', 'amg' or 'samg'}
         'auto' :
             algorithm will attempt to choose the best method for input data
         'dense' :
@@ -48,6 +48,13 @@ def ltsa(geom, n_components, eigen_solver='auto',
         'amg' :
             AMG requires pyamg to be installed. It can be faster on very large,
             sparse problems, but may also lead to instabilities.
+        'samg' :
+            Algebraic Multigrid solver from Fraunhofer SCAI (requires
+            ``Fraunhofer SAMG`` and ``pysamg`` to be installed). It can be
+            significantly faster on very large, sparse problems. Note that SAMG
+            is a commercial product and one needs a license to use it. For
+            licensing (including test or educational licenses)
+            contact samg@scai.fraunhofer.de
     random_state : numpy.RandomState or int, optional
         The generator or seed used to determine the starting vector for arpack
         iterations.  Defaults to numpy.random.
@@ -125,13 +132,12 @@ class LTSA(BaseEmbedding):
         specification of geometry parameters: keys are
         ["adjacency_method", "adjacency_kwds", "affinity_method",
          "affinity_kwds", "laplacian_method", "laplacian_kwds"]
-    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', or 'amg'}
+    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', 'amg' or 'samg'}
         'auto' :
             algorithm will attempt to choose the best method for input data
         'dense' :
-            use standard dense matrix operations for the eigenvalue
-            decomposition. Uses a dense data array, and thus should be avoided
-            for large problems.
+            use standard dense matrix operations for the eigenvalue decomposition.
+            For this method, M must be an array or matrix type.  This method should be avoided for large problems.
         'arpack' :
             use arnoldi iteration in shift-invert mode. For this method,
             M may be a dense matrix, sparse matrix, or general linear operator.
@@ -144,6 +150,13 @@ class LTSA(BaseEmbedding):
         'amg' :
             AMG requires pyamg to be installed. It can be faster on very large,
             sparse problems, but may also lead to instabilities.
+        'samg' :
+            Algebraic Multigrid solver from Fraunhofer SCAI (requires
+            ``Fraunhofer SAMG`` and ``pysamg`` to be installed). It can be
+            significantly faster on very large, sparse problems. Note that SAMG
+            is a commercial product and one needs a license to use it. For
+            licensing (including test or educational licenses)
+            contact samg@scai.fraunhofer.de
     random_state : numpy.RandomState or int, optional
         The generator or seed used to determine the starting vector for arpack
         iterations.  Defaults to numpy.random.RandomState

--- a/megaman/utils/eigendecomp.py
+++ b/megaman/utils/eigendecomp.py
@@ -12,7 +12,8 @@ from .validation import check_array
 
 EIGEN_SOLVERS = ['auto', 'dense', 'arpack', 'lobpcg', 'samg']
 BAD_EIGEN_SOLVERS = {}
-AMG_KWDS = ['strength', 'aggregate', 'smooth', 'max_levels', 'max_coarse', 'samg_param']
+AMG_KWDS = ['strength', 'aggregate', 'smooth', 'max_levels', 'max_coarse',
+            'samg_param']
 
 try:
     from pyamg import smoothed_aggregation_solver
@@ -233,19 +234,28 @@ def eigen_decomposition(G, n_components=8, eigen_solver='auto',
             warnings.warn("AMG works better for sparse matrices")
 
         ### Use SAMG to get a preconditioner and speed up the eigenvalue problem.
-        G = check_array(G, accept_sparse = ['csr']) # Ensure we're dealing with CSR matrix
+        G = check_array(G, accept_sparse = ['csr']) # Ensure we're dealing with
+                                                    # CSR matrix
 
-        ## Determine if the matrix may be too dense for standard SAMG parameters (only if the user didn't supply own SAMG parameters)
-        if 'samg_param' not in amg_kwds or all(x not in amg_kwds['samg_param'] for x in ['ncg','ecg','a_cmplx','g_cmplx','w_avrge','nwt']):
+        ## Determine if the matrix may be too dense for standard SAMG parameters
+        ## (only if the user didn't supply own SAMG parameters)
+        if ('samg_param' not in amg_kwds or all(x not in amg_kwds['samg_param']
+                    for x in ['ncg','ecg','a_cmplx','g_cmplx','w_avrge','nwt'])):
             density = G.getnnz()/G.shape[0] # Calculate the entries per row
             if density >= 40:
-                warnings.warn("The given matrix has more than 40 entries per row: switching to a more agressive coarsening to prevent overuse of memory.")
+                warnings.warn("The given matrix has more than 40 entries per "
+                              "row: switching to a more agressive coarsening to"
+                              "prevent overuse of memory.")
                 if 'samg_param' not in amg_kwds:
                     amg_kwds['samg_param'] = dict()
-                amg_kwds['samg_param'].update({'ncg':171, 'ecg':21.9, 'a_cmplx':4.5, 'g_cmplx':1.3, 'w_avrge':1.7, 'nwt':1}) # aggregative coarsening
+                # aggregative coarsening
+                amg_kwds['samg_param'].update({'ncg':171, 'ecg':21.9,
+                                               'a_cmplx':4.5, 'g_cmplx':1.3,
+                                               'w_avrge':1.7, 'nwt':1})
 
             elif density >= 20:
-                warnings.warn("The given matrix has more than 20 entries per row: standard SAMG parameters may use to much memory.")
+                warnings.warn("The given matrix has more than 20 entries per row:"
+                              "standard SAMG parameters may use to much memory.")
 
         s = SAMG.Solver(G, **(amg_kwds or {}))
         M = s.aspreconditioner()
@@ -311,7 +321,8 @@ def null_space(M, k, k_skip=1, eigen_solver='arpack',
             algorithm will attempt to choose the best method for input data
         'dense' :
             use standard dense matrix operations for the eigenvalue decomposition.
-            For this method, M must be an array or matrix type.  This method should be avoided for large problems.
+            For this method, M must be an array or matrix type.
+            This method should be avoided for large problems.
         'arpack' :
             use arnoldi iteration in shift-invert mode. For this method,
             M may be a dense matrix, sparse matrix, or general linear operator.

--- a/megaman/utils/spectral_clustering.py
+++ b/megaman/utils/spectral_clustering.py
@@ -15,14 +15,14 @@ from megaman.utils.validation import check_random_state
 
 class SpectralClustering(BaseEmbedding):
     """
-    Spectral clustering for find K clusters by using the eigenvectors of a 
+    Spectral clustering for find K clusters by using the eigenvectors of a
     matrix which is derived from a set of similarities S.
 
     Parameters
     -----------
     K: integer
         number of K clusters
-    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', or 'amg'}
+    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', 'amg' or 'samg'}
         'auto' :
             algorithm will attempt to choose the best method for input data
         'dense' :
@@ -39,31 +39,38 @@ class SpectralClustering(BaseEmbedding):
             (SPD) generalized eigenproblems.
         'amg' :
             AMG requires pyamg to be installed. It can be faster on very large,
-            sparse problems, but may also lead to instabilities.  
-            
+            sparse problems, but may also lead to instabilities.
+        'samg' :
+            Algebraic Multigrid solver from Fraunhofer SCAI (requires
+            ``Fraunhofer SAMG`` and ``pysamg`` to be installed). It can be
+            significantly faster on very large, sparse problems. Note that SAMG
+            is a commercial product and one needs a license to use it. For
+            licensing (including test or educational licenses)
+            contact samg@scai.fraunhofer.de
+
     random_state : numpy.RandomState or int, optional
         The generator or seed used to determine the starting vector for arpack
-        iterations.  Defaults to numpy.random.RandomState    
-    solver_kwds : any additional keyword arguments to pass to the selected eigen_solver    
-    renormalize : (bool) whether or not to set the rows of the eigenvectors to have norm 1 
+        iterations.  Defaults to numpy.random.RandomState
+    solver_kwds : any additional keyword arguments to pass to the selected eigen_solver
+    renormalize : (bool) whether or not to set the rows of the eigenvectors to have norm 1
                  this can improve label quality
     stabalize : (bool) whether or not to compute the (more stable) eigenvectors of L = D^-1/2*S*D^-1/2
-                instead of P = D^-1*S 
-    """    
-    def __init__(self,K,eigen_solver='auto', 
+                instead of P = D^-1*S
+    """
+    def __init__(self,K,eigen_solver='auto',
                  random_state=None, solver_kwds = None,
                  geom = None, radius = None, renormalize = True, stabalize = True,
                  additional_vectors=0):
         self.eigen_solver = eigen_solver
-        self.random_state = random_state             
+        self.random_state = random_state
         self.K = K
-        self.solver_kwds = solver_kwds 
+        self.solver_kwds = solver_kwds
         self.geom = geom
         self.radius = radius
         self.renormalize = renormalize
         self.stabalize = stabalize
         self.additional_vectors = 0
-     
+
     def fit(self, X, y=None, input_type='affinity'):
         """
         Fit the model from data in X.
@@ -78,32 +85,32 @@ class SpectralClustering(BaseEmbedding):
 
         If self.input_type is similarity:
         X : array-like, shape (n_samples, n_samples),
-            copy the similarity matrix X to S.    
+            copy the similarity matrix X to S.
         """
         X = self._validate_input(X, input_type)
         self.fit_geometry(X, input_type)
-        random_state = check_random_state(self.random_state)            
-        self.embedding_, self.eigen_vectors_, self.P_ = spectral_clustering(self.geom_, K = self.K, 
-                                                                   eigen_solver = self.eigen_solver, 
-                                                                   random_state = self.random_state, 
+        random_state = check_random_state(self.random_state)
+        self.embedding_, self.eigen_vectors_, self.P_ = spectral_clustering(self.geom_, K = self.K,
+                                                                   eigen_solver = self.eigen_solver,
+                                                                   random_state = self.random_state,
                                                                    solver_kwds = self.solver_kwds,
                                                                    renormalize = self.renormalize,
                                                                    stabalize = self.stabalize,
-                                                                   additional_vectors = self.additional_vectors)   
-                
-def spectral_clustering(geom, K, eigen_solver = 'dense', random_state = None, solver_kwds = None, 
+                                                                   additional_vectors = self.additional_vectors)
+
+def spectral_clustering(geom, K, eigen_solver = 'dense', random_state = None, solver_kwds = None,
                         renormalize = True, stabalize = True, additional_vectors = 0):
     """
-    Spectral clustering for find K clusters by using the eigenvectors of a 
+    Spectral clustering for find K clusters by using the eigenvectors of a
     matrix which is derived from a set of similarities S.
 
     Parameters
     -----------
     S: array-like,shape(n_sample,n_sample)
-        similarity matrix 
+        similarity matrix
     K: integer
         number of K clusters
-    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', or 'amg'}
+    eigen_solver : {'auto', 'dense', 'arpack', 'lobpcg', 'amg' or 'samg'}
         'auto' :
             algorithm will attempt to choose the best method for input data
         'dense' :
@@ -120,33 +127,40 @@ def spectral_clustering(geom, K, eigen_solver = 'dense', random_state = None, so
             (SPD) generalized eigenproblems.
         'amg' :
             AMG requires pyamg to be installed. It can be faster on very large,
-            sparse problems, but may also lead to instabilities.  
-            
+            sparse problems, but may also lead to instabilities.
+        'samg' :
+            Algebraic Multigrid solver from Fraunhofer SCAI (requires
+            ``Fraunhofer SAMG`` and ``pysamg`` to be installed). It can be
+            significantly faster on very large, sparse problems. Note that SAMG
+            is a commercial product and one needs a license to use it. For
+            licensing (including test or educational licenses)
+            contact samg@scai.fraunhofer.de
+
     random_state : numpy.RandomState or int, optional
         The generator or seed used to determine the starting vector for arpack
-        iterations.  Defaults to numpy.random.RandomState    
-    solver_kwds : any additional keyword arguments to pass to the selected eigen_solver 
-    renormalize : (bool) whether or not to set the rows of the eigenvectors to have norm 1 
+        iterations.  Defaults to numpy.random.RandomState
+    solver_kwds : any additional keyword arguments to pass to the selected eigen_solver
+    renormalize : (bool) whether or not to set the rows of the eigenvectors to have norm 1
                  this can improve label quality
     stabalize : (bool) whether or not to compute the (more stable) eigenvectors of L = D^-1/2*S*D^-1/2
-                instead of P = D^-1*S 
+                instead of P = D^-1*S
     additional_vectors : (int) compute additional eigen vectors when computing eigen decomposition.
-        When eigen_solver = 'amg' or 'lopcg' often if a small number of eigen values is sought the
+        When eigen_solver = 'amg', 'samg' or 'lopcg' often if a small number of eigen values is sought the
         largest eigenvalue returned is *not* equal to 1 (it should be). This can usually be fixed
         by requesting more than K eigenvalues until the first eigenvalue is close to 1 and then
-        omitted. The remaining K-1 eigenvectors should be informative. 
+        omitted. The remaining K-1 eigenvectors should be informative.
     Returns
     -------
     labels: array-like, shape (1,n_samples)
-    """ 
+    """
     # Step 1: get similarity matrix
     if geom.affinity_matrix is None:
         S = geom.compute_affinity_matrix()
     else:
         S = geom.affinity_matrix
-        
+
     # Check for stability method, symmetric solvers require this
-    if eigen_solver in ['lobpcg', 'amg']:
+    if eigen_solver in ['lobpcg', 'amg', 'samg']:
         stabalize = True
     if stabalize:
         geom.laplacian_type = 'symmetricnormalized'
@@ -154,40 +168,40 @@ def spectral_clustering(geom, K, eigen_solver = 'dense', random_state = None, so
     else:
         geom.laplacian_type = 'randomwalk'
         return_lapsym = False
-    
+
     # Step 2: get the Laplacian matrix
     P = geom.compute_laplacian_matrix(return_lapsym = return_lapsym)
     # by default the Laplacian is subtracted from the Identify matrix (this step may not be needed)
-    P += identity(P.shape[0])        
-    
-    # Step 3: Compute the top K eigenvectors and drop the first 
-    if eigen_solver in ['auto', 'amg', 'lobpcg']:
+    P += identity(P.shape[0])
+
+    # Step 3: Compute the top K eigenvectors and drop the first
+    if eigen_solver in ['auto', 'amg', 'lobpcg', 'samg']:
         n_components = 2*int(np.log(P.shape[0]))*K + 1
         n_components += int(additional_vectors)
     else:
         n_components = K
     n_components = min(n_components, P.shape[0])
-    (lambdas, eigen_vectors) = eigen_decomposition(P, n_components=n_components, eigen_solver=eigen_solver, 
+    (lambdas, eigen_vectors) = eigen_decomposition(P, n_components=n_components, eigen_solver=eigen_solver,
                                                    random_state=random_state, drop_first = True,
                                                    solver_kwds=solver_kwds)
-    # the first vector is usually uninformative 
-    if eigen_solver in ['auto', 'lobpcg', 'amg']:
+    # the first vector is usually uninformative
+    if eigen_solver in ['auto', 'lobpcg', 'amg', 'samg']:
         if np.abs(lambdas[0] - 1) > 1e-4:
             warnings.warn("largest eigenvalue not equal to 1. Results may be poor. Try increasing additional_vectors parameter")
     eigen_vectors = eigen_vectors[:, 1:K]
     lambdas = lambdas[1:K]
-    
+
     # If stability method chosen, adjust eigenvectors
     if stabalize:
         w = np.array(geom.laplacian_weights)
         eigen_vectors /= np.sqrt(w[:,np.newaxis])
-        eigen_vectors /= np.linalg.norm(eigen_vectors, axis = 0)    
-    
+        eigen_vectors /= np.linalg.norm(eigen_vectors, axis = 0)
+
     # If renormalize: set each data point to unit length
     if renormalize:
         norms = np.linalg.norm(eigen_vectors, axis=1)
         eigen_vectors /= norms[:,np.newaxis]
-    
+
     # Step 4: run k-means clustering
-    labels =  k_means_clustering(eigen_vectors,K)    
+    labels =  k_means_clustering(eigen_vectors,K)
     return labels, eigen_vectors, P

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ megaman: Manifold Learning for Millions of Points
 
 This repository contains a scalable implementation of several manifold learning
 algorithms, making use of FLANN for fast approximate nearest neighbors and
-PyAMG, LOBPCG, ARPACK, and other routines for fast matrix decompositions.
+PyAMG, Fraunhofer SAMG, LOBPCG, ARPACK, and other routines for fast matrix
+decompositions.
 
 For more information, visit https://github.com/mmp2/megaman
 """


### PR DESCRIPTION
We integrated Fraunhofer SAMG as an alternative to PyAMG as the preconditioner used in LOBPCG.

We tested this on the swiss roll as an artificial dataset and on the data from word2vec used in previous benchmarks of megaman. In both cases using SAMG proved to be significantly faster than using PyAMG. For example in our tests using SAMG on the data from word2vec we were able to achieve a speedup of the embedding process by a factor between 2 and 6.

![w2v_embeddingtime](https://cloud.githubusercontent.com/assets/21131800/21770893/8bfe8e0c-d685-11e6-8420-f91d51fadd49.png)

Note though that Fraunhofer SAMG is a commercial software and one needs a license to use it. For more information on SAMG see [here](http://scai.fraunhofer.de/samg/) and for licensing (including test or educational licenses) contact samg@scai.fraunhofer.de.